### PR TITLE
Fix building on Arch Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ SET(CMAKE_SKIP_BUILD_RPATH  TRUE)
 
 option(FETCH_PROGRAM "Build fetch program" ON)
 option(FETCH_LIBRARY "Build fetch library" OFF)
+option (USE_SYSTEM_SSL "Don't statically link the Ravenport-compatible SSL" OFF)
 
 if(FETCH_PROGRAM)
 	add_subdirectory(program)

--- a/http.c
+++ b/http.c
@@ -67,7 +67,7 @@
 #define _XOPEN_SOURCE
 #  ifdef __linux__
 #define _XOPEN_SOURCE_EXTENDED
-#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #define _GNU_SOURCE
 #  endif
 #endif

--- a/program/CMakeLists.txt
+++ b/program/CMakeLists.txt
@@ -1,12 +1,15 @@
 set (prog fetchx)
 
-# Drop ability to build with non-Ravenports products
-# Make it a build requirement to have libssl_pic.a from Ravenports
-
-set (libssl ${CMAKE_INSTALL_PREFIX}/libressl/lib/libssl_pic.a)
-set (libcrypto ${CMAKE_INSTALL_PREFIX}/libressl/lib/libcrypto_pic.a)
-set (incssl ${CMAKE_CURRENT_SOURCE_DIR}
-            ${CMAKE_INSTALL_PREFIX}/libressl/include)
+if (USE_SYSTEM_SSL)
+	set (libssl ssl)
+	set (libcrypto crypto)
+	set (incssl "")
+else()
+	set (libssl ${CMAKE_INSTALL_PREFIX}/libressl/lib/libssl_pic.a)
+	set (libcrypto ${CMAKE_INSTALL_PREFIX}/libressl/lib/libcrypto_pic.a)
+	set (incssl ${CMAKE_CURRENT_SOURCE_DIR}
+		    ${CMAKE_INSTALL_PREFIX}/libressl/include)
+endif()
 
 set (libs ${libssl} ${libcrypto})
 


### PR DESCRIPTION
So, I should say, I have no idea what Ravenports is, and was not able to figure it out. I guess, it is another package manager. Anyway, it's not available in Arch User Repository, so am not really too concerned about it.

Due to my profound ignorance though, I guess you may have good reasons not to want this PR, but it does work for me and makes `fetch` buildable on Arch. I can then do...

```bash
cp program/fetchx ~/.bin/fetch
```

And use some scripts I have that use a lot of `fetch` without issue. And I like it more than `wget` anyway.

I made an AUR package: https://aur.archlinux.org/packages/fetch/

PKGBUILD: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=fetch