### PR TITLE
Use GNUInstallDirs to set installation directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ option(FETCH_PROGRAM "Build fetch program" ON)
 option(FETCH_LIBRARY "Build fetch library" OFF)
 option(USE_SYSTEM_SSL "Don't statically link the Ravenport-compatible SSL" OFF)
 
+include(GNUInstallDirs)
+
 if(FETCH_PROGRAM)
 	add_subdirectory(program)
 endif()

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -62,11 +62,11 @@ install(TARGETS fetch_pic
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libfetch_static.a
 	RENAME libfetch.a
-	DESTINATION lib
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
 install(FILES ${CMAKE_SOURCE_DIR}/fetch-estream.h
 	${CMAKE_SOURCE_DIR}/fetch.h
-	DESTINATION include
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
-install(FILES ${CMAKE_SOURCE_DIR}/fetch.3 DESTINATION share/man/man3)
+install(FILES ${CMAKE_SOURCE_DIR}/fetch.3 DESTINATION ${CMAKE_INSTALL_MANDIR}/man3)

--- a/program/CMakeLists.txt
+++ b/program/CMakeLists.txt
@@ -57,6 +57,6 @@ target_include_directories(${prog} PUBLIC
 )
 target_compile_options(${prog} PUBLIC -Wno-psabi)
 
-# install(TARGETS ${prog} DESTINATION bin)
-install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${prog} DESTINATION bin RENAME fetch)
-install(FILES ${CMAKE_SOURCE_DIR}/fetch.1 DESTINATION share/man/man1)
+# install(TARGETS ${prog} DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${prog} DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME fetch)
+install(FILES ${CMAKE_SOURCE_DIR}/fetch.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)


### PR DESCRIPTION
Allows the installation directories to be set via standard arguments, say for `CMAKE_INSTALL_LIBDIR`. (setting it to `lib64` instead of `lib` as some distros do)