### PR TITLE
Sync with 14

### DIFF
--- a/common.c
+++ b/common.c
@@ -849,9 +849,7 @@ fetch_ssl_setup_transport_layer(SSL_CTX *ctx, int verbose)
 {
 	long ssl_ctx_options;
 
-	ssl_ctx_options = SSL_OP_ALL | SSL_OP_NO_SSLv2 | SSL_OP_NO_TICKET;
-	if (getenv("SSL_ALLOW_SSL3") == NULL)
-		ssl_ctx_options |= SSL_OP_NO_SSLv3;
+	ssl_ctx_options = SSL_OP_ALL | SSL_OP_NO_SSLv3 | SSL_OP_NO_TICKET;
 	if (getenv("SSL_NO_TLS1") != NULL)
 		ssl_ctx_options |= SSL_OP_NO_TLSv1;
 	if (getenv("SSL_NO_TLS1_1") != NULL)

--- a/common.c
+++ b/common.c
@@ -745,24 +745,8 @@ fetch_ssl_verify_altname(STACK_OF(GENERAL_NAME) *altnames,
 	const char *ns;
 
 	for (i = 0; i < sk_GENERAL_NAME_num(altnames); ++i) {
-#if OPENSSL_VERSION_NUMBER < 0x10000000L
-		/*
-		 * This is a workaround, since the following line causes
-		 * alignment issues in clang:
-		 * name = sk_GENERAL_NAME_value(altnames, i);
-		 * OpenSSL explicitly warns not to use those macros
-		 * directly, but there isn't much choice (and there
-		 * shouldn't be any ill side effects)
-		 */
-		name = (GENERAL_NAME *)SKM_sk_value(void, altnames, i);
-#else
 		name = sk_GENERAL_NAME_value(altnames, i);
-#endif
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-		ns = (const char *)ASN1_STRING_data(name->d.ia5);
-#else
 		ns = (const char *)ASN1_STRING_get0_data(name->d.ia5);
-#endif
 		nslen = (size_t)ASN1_STRING_length(name->d.ia5);
 
 		if (name->type == GEN_DNS && ip == NULL &&
@@ -997,16 +981,6 @@ fetch_ssl(conn_t *conn, const struct url *URL, int verbose)
 	X509_NAME *name;
 	char *str;
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-	/* Init the SSL library and context */
-	if (!SSL_library_init()){
-		fprintf(stderr, "SSL library init failed\n");
-		return (-1);
-	}
-
-	SSL_load_error_strings();
-#endif
-
 	conn->ssl_meth = SSLv23_client_method();
 	conn->ssl_ctx = SSL_CTX_new(conn->ssl_meth);
 	SSL_CTX_set_mode(conn->ssl_ctx, SSL_MODE_AUTO_RETRY);
@@ -1024,7 +998,7 @@ fetch_ssl(conn_t *conn, const struct url *URL, int verbose)
 	}
 	SSL_set_fd(conn->ssl, conn->sd);
 
-#if OPENSSL_VERSION_NUMBER >= 0x0090806fL && !defined(OPENSSL_NO_TLSEXT)
+#if !defined(OPENSSL_NO_TLSEXT)
 	if (!SSL_set_tlsext_host_name(conn->ssl,
 	    __DECONST(struct url *, URL)->host)) {
 		fprintf(stderr,

--- a/common.c
+++ b/common.c
@@ -1149,7 +1149,7 @@ fetch_read(conn_t *conn, char *buf, size_t len)
 			}
 			timersub(&timeout, &now, &delta);
 			deltams = delta.tv_sec * 1000 +
-			    delta.tv_usec / 1000;;
+			    delta.tv_usec / 1000;
 		}
 		errno = 0;
 		pfd.revents = 0;

--- a/common.c
+++ b/common.c
@@ -997,6 +997,7 @@ fetch_ssl(conn_t *conn, const struct url *URL, int verbose)
 	X509_NAME *name;
 	char *str;
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	/* Init the SSL library and context */
 	if (!SSL_library_init()){
 		fprintf(stderr, "SSL library init failed\n");
@@ -1004,6 +1005,7 @@ fetch_ssl(conn_t *conn, const struct url *URL, int verbose)
 	}
 
 	SSL_load_error_strings();
+#endif
 
 	conn->ssl_meth = SSLv23_client_method();
 	conn->ssl_ctx = SSL_CTX_new(conn->ssl_meth);

--- a/common.c
+++ b/common.c
@@ -112,12 +112,15 @@ jrm_strchrnul(const char *p, int ch)
  * Error messages for resolver errors
  */
 static struct fetcherr netdb_errlist[] = {
+#ifdef EAI_ADDRFAMILY
+	{ EAI_ADDRFAMILY, FETCH_RESOLV, "Address family for host not supported" },
+#endif
 #ifdef EAI_NODATA
-	{ EAI_NODATA,	FETCH_RESOLV,	"Host not found" },
+	{ EAI_NODATA,	FETCH_RESOLV,	"No address for host" },
 #endif
 	{ EAI_AGAIN,	FETCH_TEMP,	"Transient resolver failure" },
 	{ EAI_FAIL,	FETCH_RESOLV,	"Non-recoverable resolver failure" },
-	{ EAI_NONAME,	FETCH_RESOLV,	"No address record" },
+	{ EAI_NONAME,	FETCH_RESOLV,	"Host does not resolve" },
 	{ -1,		FETCH_UNKNOWN,	"Unknown resolver error" }
 };
 

--- a/fetch.3
+++ b/fetch.3
@@ -26,7 +26,7 @@
 .\"
 .\" $FreeBSD: head/lib/libfetch/fetch.3 297355 2016-03-28 16:48:28Z trasz $
 .\"
-.Dd July 10, 2019
+.Dd August 28, 2019
 .Dt FETCH 3
 .Os
 .Sh NAME
@@ -48,6 +48,7 @@
 .Nm fetchPutFile ,
 .Nm fetchStatFile ,
 .Nm fetchListFile ,
+.Nm fetchReqHTTP ,
 .Nm fetchXGetHTTP ,
 .Nm fetchGetHTTP ,
 .Nm fetchPutHTTP ,
@@ -111,6 +112,8 @@
 .Fn fetchStatHTTP "struct url *u" "struct url_stat *us" "const char *flags"
 .Ft struct url_ent *
 .Fn fetchListHTTP "struct url *u" "const char *flags"
+.Ft FXRETTYPE
+.Fn fetchReqHTTP "struct url *u" "const char *method" "const char *flags" "const char *content_type" "const char *body"
 .Ft FXRETTYPE
 .Fn fetchXGetFTP "struct url *u" "struct url_stat *us" "const char *flags"
 .Ft FXRETTYPE
@@ -361,9 +364,10 @@ and password "anonymous@<hostname>".
 .Sh HTTP SCHEME
 The
 .Fn fetchXGetHTTP ,
-.Fn fetchGetHTTP
+.Fn fetchGetHTTP ,
+.Fn fetchPutHTTP ,
 and
-.Fn fetchPutHTTP
+.Fn fetchReqHTTP
 functions implement the HTTP/1.1 protocol.
 With a little luck, there is
 even a chance that they comply with RFC2616 and RFC2617.
@@ -392,6 +396,18 @@ will send a conditional
 .Li If-Modified-Since
 HTTP header to only fetch the content if it is newer than
 .Va ims_time .
+.Pp
+The function
+.Fn fetchReqHTTP
+can be used to make requests with an arbitrary HTTP verb,
+including POST, DELETE, CONNECT, OPTIONS, TRACE or PATCH.
+This can be done by setting the argument
+.Fa method
+to the intended verb, such as
+.Ql POST ,
+and
+.Fa body
+to the content.
 .Pp
 Since there seems to be no good way of implementing the HTTP PUT
 method in a manner consistent with the rest of the

--- a/fetch.3
+++ b/fetch.3
@@ -463,8 +463,7 @@ the environment variable
 .Ev SSL_CLIENT_KEY_FILE
 can be set to point to the key file.
 In case the key uses a password, the user will be prompted on standard
-input (see
-.Xr PEM 3 ) .
+input.
 .Pp
 By default
 .Nm libfetch

--- a/fetch.3
+++ b/fetch.3
@@ -26,7 +26,7 @@
 .\"
 .\" $FreeBSD: head/lib/libfetch/fetch.3 297355 2016-03-28 16:48:28Z trasz $
 .\"
-.Dd August 28, 2019
+.Dd November 24, 2020
 .Dt FETCH 3
 .Os
 .Sh NAME
@@ -471,12 +471,10 @@ By default
 allows TLSv1 and newer when negotiating the connecting with the remote
 peer.
 You can change this behavior by setting the
-.Ev SSL_ALLOW_SSL3
-environment variable to allow SSLv3 and
 .Ev SSL_NO_TLS1 ,
 .Ev SSL_NO_TLS1_1 and
 .Ev SSL_NO_TLS1_2
-to disable TLS 1.0, 1.1 and 1.2 respectively.
+environment variables to disable TLS 1.0, 1.1 and 1.2 respectively.
 .Sh AUTHENTICATION
 Apart from setting the appropriate environment variables and
 specifying the user name and password in the URL or the
@@ -674,8 +672,6 @@ which proxies should not be used.
 Same as
 .Ev NO_PROXY ,
 for compatibility.
-.It Ev SSL_ALLOW_SSL3
-Allow SSL version 3 when negotiating the connection (not recommended).
 .It Ev SSL_CA_CERT_FILE
 CA certificate bundle containing trusted CA certificates.
 Default value: See HTTPS SCHEME above.

--- a/fetch.c
+++ b/fetch.c
@@ -427,7 +427,7 @@ fetchParseURL(const char *URL)
 				goto ouch;
 			}
 		}
-		if (n < 1 || n > IPPORT_MAX)
+		if (p != q && (n < 1 || n > IPPORT_MAX))
 			goto ouch;
 		u->port = n;
 		p = q;

--- a/fetch.c
+++ b/fetch.c
@@ -325,6 +325,9 @@ fetch_pctdecode(char *dst, const char *src, size_t dlen)
 		    (d2 = fetch_hexval(s[2])) >= 0 && (d1 > 0 || d2 > 0)) {
 			c = d1 << 4 | d2;
 			s += 2;
+		} else if (s[0] == '%') {
+			/* Invalid escape sequence. */
+			return (NULL);
 		} else {
 			c = *s;
 		}

--- a/fetch.c
+++ b/fetch.c
@@ -448,7 +448,10 @@ nohost:
 			goto ouch;
 		}
 		u->doc = doc;
-		while (*p != '\0') {
+		/* fragments are reserved for client-side processing, see
+		 * https://www.rfc-editor.org/rfc/rfc9110.html#section-7.1
+		 */
+		while (*p != '\0' && *p != '#') {
 			if (!isspace((unsigned char)*p)) {
 				*doc++ = *p++;
 			} else {

--- a/fetch.c
+++ b/fetch.c
@@ -400,7 +400,7 @@ fetchParseURL(const char *URL)
 
 	/* hostname */
 	if (*p == '[') {
-		q = p + 1 + strspn(p + 1, ":0123456789ABCDEFabcdef");
+		q = p + 1 + strspn(p + 1, ":0123456789ABCDEFabcdef.");
 		if (*q++ != ']')
 			goto ouch;
 	} else {

--- a/http.c
+++ b/http.c
@@ -1524,7 +1524,7 @@ retry:
 				 * No auth information found in system - exiting
 				 * with warning.
 				 */
-				warnx("Missing username and/or password set");
+				fprintf(stderr, "Missing username and/or password set\n");
 				fetch_syserr();
 				goto ouch;
 			}

--- a/http.c
+++ b/http.c
@@ -1037,13 +1037,12 @@ http_base64(const char *src)
 	    "0123456789+/";
 	char *str, *dst;
 	size_t l;
-	int t, r;
+	int t;
 
 	l = strlen(src);
 	if ((str = malloc(((l + 2) / 3) * 4 + 1)) == NULL)
 		return (NULL);
 	dst = str;
-	r = 0;
 
 	while (l >= 3) {
 		t = (src[0] << 16) | (src[1] << 8) | src[2];
@@ -1052,7 +1051,7 @@ http_base64(const char *src)
 		dst[2] = base64[(t >> 6) & 0x3f];
 		dst[3] = base64[(t >> 0) & 0x3f];
 		src += 3; l -= 3;
-		dst += 4; r += 4;
+		dst += 4;
 	}
 
 	switch (l) {
@@ -1063,7 +1062,6 @@ http_base64(const char *src)
 		dst[2] = base64[(t >> 6) & 0x3f];
 		dst[3] = '=';
 		dst += 4;
-		r += 4;
 		break;
 	case 1:
 		t = src[0] << 16;
@@ -1071,7 +1069,6 @@ http_base64(const char *src)
 		dst[1] = base64[(t >> 12) & 0x3f];
 		dst[2] = dst[3] = '=';
 		dst += 4;
-		r += 4;
 		break;
 	case 0:
 		break;

--- a/http.c
+++ b/http.c
@@ -2205,6 +2205,9 @@ fetchListHTTP(struct url *url __unused, const char *flags __unused)
 	return (NULL);
 }
 
+/*
+ * Arbitrary HTTP verb and content requests
+ */
 FXRETTYPE
 fetchReqHTTP(struct url *URL, const char *method, const char *flags,
 	const char *content_type, const char *body)

--- a/http.c
+++ b/http.c
@@ -83,6 +83,7 @@
 #include <locale.h>
 #include <netdb.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1477,6 +1478,8 @@ http_connect(struct url *URL, struct url *purl, const char *flags)
 	int val;
 #endif
 	int serrno;
+	bool isproxyauth = false;
+	http_auth_challenges_t proxy_challenges;
 
 #ifdef INET6
 	af = AF_UNSPEC;
@@ -1494,18 +1497,58 @@ http_connect(struct url *URL, struct url *purl, const char *flags)
 
 	curl = (purl != NULL) ? purl : URL;
 
+retry:
 	if ((conn = fetch_connect(curl->host, curl->port, af, verbose)) == NULL)
 		/* fetch_connect() has already set an error code */
 		return (NULL);
 	init_http_headerbuf(&headerbuf);
 	if (strcmp(URL->scheme, SCHEME_HTTPS) == 0 && purl) {
-		http_cmd(conn, "CONNECT %s:%d HTTP/1.1",
-		    URL->host, URL->port);
-		http_cmd(conn, "Host: %s:%d",
-		    URL->host, URL->port);
+		init_http_auth_challenges(&proxy_challenges);
+		http_cmd(conn, "CONNECT %s:%d HTTP/1.1", URL->host, URL->port);
+		http_cmd(conn, "Host: %s:%d", URL->host, URL->port);
+		if (isproxyauth) {
+			http_auth_params_t aparams;
+			init_http_auth_params(&aparams);
+			if (*purl->user || *purl->pwd) {
+				aparams.user = strdup(purl->user);
+				aparams.password = strdup(purl->pwd);
+			} else if ((p = getenv("HTTP_PROXY_AUTH")) != NULL &&
+				    *p != '\0') {
+				if (http_authfromenv(p, &aparams) < 0) {
+					http_seterr(HTTP_NEED_PROXY_AUTH);
+					fetch_syserr();
+					goto ouch;
+				}
+			} else if (fetch_netrc_auth(purl) == 0) {
+				aparams.user = strdup(purl->user);
+				aparams.password = strdup(purl->pwd);
+			} else {
+				/*
+				 * No auth information found in system - exiting
+				 * with warning.
+				 */
+				warnx("Missing username and/or password set");
+				fetch_syserr();
+				goto ouch;
+			}
+			http_authorize(conn, "Proxy-Authorization",
+			    &proxy_challenges, &aparams, purl);
+			clean_http_auth_params(&aparams);
+		}
 		http_cmd(conn, "");
-		if (http_get_reply(conn) != HTTP_OK) {
-			http_seterr(conn->err);
+		/* Get reply from CONNECT Tunnel attempt */
+		int httpreply = http_get_reply(conn);
+		if (httpreply != HTTP_OK) {
+			http_seterr(httpreply);
+			/* If the error is a 407/HTTP_NEED_PROXY_AUTH */
+			if (httpreply == HTTP_NEED_PROXY_AUTH &&
+			    ! isproxyauth) {
+				/* Try again with authentication. */
+				clean_http_headerbuf(&headerbuf);
+				fetch_close(conn);
+				isproxyauth = true;
+				goto retry;
+			}
 			goto ouch;
 		}
 		/* Read and discard the rest of the proxy response */

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -52,6 +52,9 @@ set_target_properties(fetch PROPERTIES SOVERSION 1)
 target_compile_options(fetchobj PUBLIC -Wno-psabi)
 target_compile_options(fetch_static PUBLIC -Wno-psabi)
 
+target_compile_definitions(fetchobj PUBLIC OPENSSL_API_COMPAT=0x10100000L)
+target_compile_definitions(fetch_static PUBLIC OPENSSL_API_COMPAT=0x10100000L)
+
 install(TARGETS fetch
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )


### PR DESCRIPTION
This brings fetch up with the FreeBSD 14 version with 2 exceptions:
1) No socks5 support 
2) The cert file is still hardcoded -- no support for freebsd's cert service